### PR TITLE
Disable uppercase transform for headers

### DIFF
--- a/source/_static/style.css
+++ b/source/_static/style.css
@@ -1,0 +1,4 @@
+/* Disable uppercase transformed headers  */
+h4, h5, h6 {
+    text-transform: none;
+}

--- a/source/conf.py
+++ b/source/conf.py
@@ -61,4 +61,8 @@ html_theme_options = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+html_css_files = [
+    'style.css',
+]
+
 highlight_language = 'none'


### PR DESCRIPTION
## Purpose

The current theme tranforms subheaders to uppercase, this is a problem for headers where the casing is important, such as the CIS-1.

## Changes

- Add custom stylesheet

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
