### PR TITLE
Add CIS1 transfer requirement for operators being treated as owners

### DIFF
--- a/source/CIS/cis-1.rst
+++ b/source/CIS/cis-1.rst
@@ -218,7 +218,7 @@ Requirements
 - A transfer of a token amount zero MUST be executed as a normal transfer.
 - A transfer of some amount of a token type MUST only transfer the exact amount of the given token type between balances.
 - A transfer of any amount of a token type to a contract address MUST call receive hook function on the receiving smart contract with a :ref:`receive hook parameter<CIS-1-functions-transfer-receive-hook-parameter>`.
-- Let ``operator`` be an operator of the address ``owner``, a transfer of any amount of a token type from an address ``owner`` sent by an address ``operator`` MUST be executed as if the transfer was sent by ``owner``.
+- Let ``operator`` be an operator of the address ``owner``. A transfer of any amount of a token type from an address ``owner`` sent by an address ``operator`` MUST be executed as if the transfer was sent by ``owner``.
 - The contract function MUST reject if a receive hook function called on the contract receiving tokens rejects.
 
 .. warning::


### PR DESCRIPTION
## Purpose

Currently, there are no explicit requirements for what operators can do, this will add a requirement saying that a transfer from some address `owner` sent by an operator of `owner` must be treated as if it was sent by `owner`

