### PR TITLE
Use URL Json object for images in CIS1 metadata

### DIFF
--- a/source/CIS/cis-1.rst
+++ b/source/CIS/cis-1.rst
@@ -448,10 +448,10 @@ All of the fields in the JSON file are optional, and this specification reserves
     - string
     - A description for this token type.
   * - ``thumbnail`` (optional)
-    - string
+    - URL JSON object
     - An image URL to a small image for displaying the asset.
   * - ``display`` (optional)
-    - string
+    - URL JSON object
     - An image URL to a large image for displaying the asset.
   * - ``artifact`` (optional)
     - URL JSON object


### PR DESCRIPTION
## Purpose

Update CIS-1 to use URL JSON objects for images in the token metadata.
This was an oversight, and the token metadata examples already follow this.

## Changes

- Set the JSON Value type for `thumbnail` and `display` to URL JSON object instead of string.

