### PR TITLE
CIS-1: Token metadata query and remove contract only error

### DIFF
--- a/source/CIS/cis-1.rst
+++ b/source/CIS/cis-1.rst
@@ -321,6 +321,51 @@ Requirements
 
   - A query MUST fail if the token ID is unknown with error: :ref:`INVALID_TOKEN_ID<CIS-1-rejection-errors>`.
 
+.. _CIS-1-functions-operatorOf:
+
+``operatorOf``
+^^^^^^^^^^^^^^
+
+Query operators with a list of owner address paired with an address to check for being an operator for the owner address.
+
+Parameter
+~~~~~~~~~
+
+The parameter consists of a name of the contract address and receive function to callback with the result and a list of address pairs.
+
+It is serialized as: a :ref:`CIS-1-ContractAddress` (``resultContract``) then a :ref:`CIS-1-ReceiveHookName` (``resultHook``) followed by 2 bytes for the number of queries (``n``) and then this number of queries (``queries``).
+A query is serialized as :ref:`CIS-1-Address` (``owner``) followed by :ref:`CIS-1-Address` (``address``)::
+
+  OperatorOfQuery ::= (owner: Address) (address: Address)
+
+  OperatorOfParameter ::= (resultContract: ContractAddress) (resultHook: ReceiveHookName) (n: Byte²) (queries: OperatorOfQueryⁿ)
+
+.. note::
+
+  Be aware of the size limit on contract function parameters which currently is 1024 bytes, which puts a limit on the number of queries depending on the name of the receive function.
+
+Result parameter
+~~~~~~~~~~~~~~~~
+
+The parameter for the callback receive function is a list of query and boolean pairs.
+
+It is serialized as: 2 bytes for the number of query-boolean pairs (``n``) and then this number of pairs (``results``).
+A query-boolean pair is serialized as a query (``query``) and then a byte with value 0 for false and 1 for true (``isOperator``)::
+
+  Bool ::= (0: Byte) // False
+         | (1: Byte) // True
+
+  OperatorOfQueryResult ::= (query: OperatorOfQuery) (isOperator: Bool)
+
+  OperatorOfResultParameter ::= (n: Byte²) (results: OperatorOfQueryResultⁿ)
+
+Requirements
+~~~~~~~~~~~~
+
+- The contract function MUST NOT increase or decrease the balance of any address for any token type.
+- The contract function MUST NOT add or remove any operator for any address.
+- The contract function MUST reject if any of the queries fails.
+
 .. _CIS-1-functions-tokenMetadata:
 
 ``tokenMetadata``

--- a/source/CIS/cis-1.rst
+++ b/source/CIS/cis-1.rst
@@ -464,7 +464,7 @@ A smart contract following this specification MUST reject the specified errors f
     - An address balance contains insufficient amount of tokens to complete some transfer of a token.
   * - UNAUTHORIZED
     - -42000003
-    - Sender is unauthorized to call this function. Note authorization is not mandated anywhere in this specification, but can still be introduce on top of the standard.
+    - Sender is unauthorized to call this function. Note authorization is not mandated anywhere in this specification, but can still be introduced on top of the standard.
 
 The smart contract implementing this specification MAY introduce custom error codes other than the ones specified in the table above.
 
@@ -662,19 +662,19 @@ The specification only has a ``transfer`` smart contract function which takes li
 This will result in lower energy cost compared to multiple contract calls and only introduces a small overhead for single transfers.
 The reason for not also including a single transfer function is to have smaller smart contract modules, which in turn leads to saving cost on every function call.
 
-No explicit authentication
---------------------------
+No explicit authorization
+-------------------------
 
-The specification does not mandate any authentication scheme and one might expect a requirement for the owner and operators being authenticated to transfer tokens.
+The specification does not mandate any authorization scheme and one might expect a requirement for the owner and operators being authorized to transfer tokens.
 This is very much intentional and the reasoning for this is to keep the specification focused on the interface for transferring token ownership with as few restrictions as possible.
 
-Having a requirement that only owners and operators can transfer would prevent introducing any other authentication scheme on top of this specification.
+Having a requirement that only owners and operators can transfer would prevent introducing any other authorization scheme on top of this specification.
 
 Adding a requirement for owners and operators being authorized to transfer tokens would prevent introducing custom contract logic rejecting transfers, such as limiting the daily transfers, temporary token lockups or non-transferrable tokens.
 
-Instead this specification includes a requirement to ensure transfers by operators are executed as if they are sent by the owner, meaning whenever a token owner is authenticated, so is an operator of the owner.
+Instead this specification includes a requirement to ensure transfers by operators are executed as if they are sent by the owner, meaning whenever a token owner is authorized, so is an operator of the owner.
 
-Most contract implementing this specification should probably add some authentication and not have anyone being able to transfer any token, but this is not really relevant for the interface described in this specification.
+Most contract implementing this specification should probably add some authorization and not have anyone being able to transfer any token, but this is not really relevant for the interface described in this specification.
 
 No token level approval/allowance like in ERC20 and ERC721
 ----------------------------------------------------------
@@ -688,7 +688,7 @@ The main argument is simplicity and to save energy cost on common cases, but oth
 
 .. note::
 
-  The specification does not prevent adding more fine-grained authentication, such as a token level operators.
+  The specification does not prevent adding more fine-grained authorization, such as a token level operators.
 
 Receive hook function
 ---------------------

--- a/source/CIS/cis-1.rst
+++ b/source/CIS/cis-1.rst
@@ -365,7 +365,7 @@ Requirements
 
 - The contract function MUST NOT increase or decrease the balance of any address for any token type.
 - The contract function MUST NOT add or remove any operator for any address.
-- The contract function MUST reject if any of the queries fails.
+- The contract function MUST reject if any of the queries fail.
 
 .. _CIS-1-functions-tokenMetadata:
 
@@ -385,7 +385,7 @@ It is serialized as: a :ref:`CIS-1-ContractAddress` (``resultContract``) then a 
 
 .. note::
 
-  Be aware of the size limit on contract function parameters which currently is 1024 bytes, which puts a limit on the number of queries depending on the byte size of the Token ID and the name of the receive function.
+  Be aware of the size limit on contract function parameters which is currently 1024 bytes, which puts a limit on the number of queries depending on the byte size of the Token ID and the name of the receive function.
 
 
 Result parameter
@@ -734,7 +734,7 @@ No token-level approval/allowance like in ERC20 and ERC721
 This standard only specifies address-level operators and not token-level operators.
 The main argument is simplicity and to save energy cost on common cases, but other reasons are:
 
-- Token-level operators requires the token smart contract to track more state, which increases the overall energy cost.
+- Token-level operators require the token smart contract to track more state, which increases the overall energy cost.
 - For token smart contracts with a lot of token types, such as a smart contract with a large collection of NFTs, token-level operators could become very expensive.
 - For fungible tokens; `approval/allowance introduces an attack vector <https://docs.google.com/document/d/1YLPtQxZu1UAvO9cZ1O2RPXBbT0mooh4DYKjA_jp-RLM/edit>`_.
 

--- a/source/CIS/cis-1.rst
+++ b/source/CIS/cis-1.rst
@@ -326,7 +326,7 @@ Requirements
 ``operatorOf``
 ^^^^^^^^^^^^^^
 
-Query operators with a list of owner address paired with an address to check for being an operator for the owner address.
+Query operators with a list of pairs, an owner address and a potential operator address, to check whether the potential operator address is an operator for the owner address.
 
 Parameter
 ~~~~~~~~~
@@ -371,12 +371,12 @@ Requirements
 ``tokenMetadata``
 ^^^^^^^^^^^^^^^^^
 
-Query the current token metadata URLs for a list token IDs, the result is then sent to a provided contract address.
+Query the current token metadata URLs for a list of token IDs, and send the result to a provided contract address.
 
 Parameter
 ~~~~~~~~~
 
-The parameter consists of a name of the contract address and receive function to callback with the result and a list of token ID.
+The parameter consists of a name of the contract address and receive function to callback with the result and a list of token IDs.
 
 It is serialized as: a :ref:`CIS-1-ContractAddress` (``resultContract``) then a :ref:`CIS-1-ReceiveHookName` (``resultHook``) followed by 1 byte for the number of queries (``n``) and then this number of :ref:`CIS-1-TokenID` (``ids``)::
 
@@ -480,7 +480,7 @@ The ``UpdateOperatorEvent`` event is serialized as: first a byte with the value 
 
 The event to log when setting the metadata url for a token type.
 It consists of a token ID and an URL (:rfc:`3986`) for the location of the metadata for this token type with an optional SHA256 checksum of the content.
-Logging the ``TokenMetadataEvent`` event again with the same token ID, is used to update the metadata location and only the most recently logged token metadata event for certain token id should be used to get the token metadata.
+Logging the ``TokenMetadataEvent`` event again with the same token ID, is used to update the metadata location and only the most recently logged token metadata event for a certain token ID should be used to get the token metadata.
 
 The ``TokenMetadataEvent`` event is serialized as: first a byte with the value of 251, followed by the token ID :ref:`CIS-1-TokenID` (``id``) and then a :ref:`CIS-1-MetadataUrl` (``metadata``)::
 
@@ -722,23 +722,23 @@ Having a requirement that only owners and operators can transfer would prevent i
 
 Adding a requirement for owners and operators being authorized to transfer tokens would prevent introducing custom contract logic rejecting transfers, such as limiting the daily transfers, temporary token lockups or non-transferrable tokens.
 
-Instead this specification includes a requirement to ensure transfers by operators are executed as if they are sent by the owner, meaning whenever a token owner is authorized, so is an operator of the owner.
+Instead, this specification includes a requirement to ensure transfers by operators are executed as if they are sent by the owner, meaning whenever a token owner is authorized, so is an operator of the owner.
 
-Most contract implementing this specification should probably add some authorization and not have anyone being able to transfer any token, but this is not really relevant for the interface described in this specification.
+Most contracts implementing this specification should probably add some authorization and not have anyone being able to transfer any token, but this is not really relevant for the interface described in this specification.
 
-No token level approval/allowance like in ERC20 and ERC721
+No token-level approval/allowance like in ERC20 and ERC721
 ----------------------------------------------------------
 
-This standard only specifies address-level operators and is not scoped to a token type.
+This standard only specifies address-level operators and not token-level operators.
 The main argument is simplicity and to save energy cost on common cases, but other reasons are:
 
-- A token level operator requires the token smart contract to track more state, which increases the overall energy cost.
-- For token smart contracts with a lot of token types, such as a smart contract with a large collection of NFTs, a token level operator could become very expensive.
+- Token-level operators requires the token smart contract to track more state, which increases the overall energy cost.
+- For token smart contracts with a lot of token types, such as a smart contract with a large collection of NFTs, token-level operators could become very expensive.
 - For fungible tokens; `approval/allowance introduces an attack vector <https://docs.google.com/document/d/1YLPtQxZu1UAvO9cZ1O2RPXBbT0mooh4DYKjA_jp-RLM/edit>`_.
 
 .. note::
 
-  The specification does not prevent adding more fine-grained authorization, such as a token level operators.
+  The specification does not prevent adding more fine-grained authorization, such as token-level operators.
 
 Receive hook function
 ---------------------

--- a/source/CIS/cis-1.rst
+++ b/source/CIS/cis-1.rst
@@ -274,6 +274,7 @@ Requirements
 
 - The list of updates MUST be executed in order.
 - The contract function MUST NOT increase or decrease the balance of any address for any token type.
+- The balance of an address not owning any amount of a token type SHOULD be treated as having a balance of zero.
 - The contract function MUST reject if any of the updates fails to be executed.
 
 .. _CIS-1-functions-balanceOf:
@@ -302,7 +303,7 @@ A query is serialized as :ref:`CIS-1-TokenID` (``id``) followed by :ref:`CIS-1-A
 Result parameter
 ~~~~~~~~~~~~~~~~
 
-The parameter for the callback receive function is a list of query and token amount pairs.
+The parameter for the callback receive function is a list of pairs, where each pair is a query and an amount of tokens.
 
 It is serialized as: 2 bytes for the number of query-amount pairs (``n``) and then this number of pairs (``results``).
 A query-amount pair is serialized as a query (``query``) and then a :ref:`CIS-1-TokenAmount` (``amount``)::
@@ -347,7 +348,7 @@ A query is serialized as :ref:`CIS-1-Address` (``owner``) followed by :ref:`CIS-
 Result parameter
 ~~~~~~~~~~~~~~~~
 
-The parameter for the callback receive function is a list of query and boolean pairs.
+The parameter for the callback receive function is a list of pairs, where each pair consist of a query and a boolean.
 
 It is serialized as: 2 bytes for the number of query-boolean pairs (``n``) and then this number of pairs (``results``).
 A query-boolean pair is serialized as a query (``query``) and then a byte with value 0 for false and 1 for true (``isOperator``)::
@@ -390,9 +391,9 @@ It is serialized as: a :ref:`CIS-1-ContractAddress` (``resultContract``) then a 
 Result parameter
 ~~~~~~~~~~~~~~~~
 
-The parameter for the callback receive function is a list of token ID and metadata URL pairs.
+The parameter for the callback receive function is a list of pairs, where each pair consist of a token ID and the corresponding token metadata URL.
 
-It is serialized as: 2 bytes for the number of query-amount pairs (``n``) and then this number of pairs (``results``).
+It is serialized as: 2 bytes for the number of queries (``n``) and then this number of result pairs (``results``).
 A pair is serialized as a :ref:`CIS-1-TokenID` (``id``) and then a :ref:`CIS-1-MetadataUrl` (``metadata``)::
 
   TokenMetadataResult ::= (id: TokenID) (metadata: MetadataUrl)
@@ -479,8 +480,9 @@ The ``UpdateOperatorEvent`` event is serialized as: first a byte with the value 
 ^^^^^^^^^^^^^^^^^^^^^^
 
 The event to log when setting the metadata url for a token type.
-It consists of a token ID and an URL (:rfc:`3986`) for the location of the metadata for this token type with an optional SHA256 checksum of the content.
-Logging the ``TokenMetadataEvent`` event again with the same token ID, is used to update the metadata location and only the most recently logged token metadata event for a certain token ID should be used to get the token metadata.
+
+It consists of a token ID and a URL (:rfc:`3986`) for the location of the metadata for this token type with an optional SHA256 checksum of the content.
+Logging the ``TokenMetadataEvent`` event again with the same token ID, is used to update the metadata location and only the most recently logged token metadata event for certain token id should be used to get the token metadata.
 
 The ``TokenMetadataEvent`` event is serialized as: first a byte with the value of 251, followed by the token ID :ref:`CIS-1-TokenID` (``id``) and then a :ref:`CIS-1-MetadataUrl` (``metadata``)::
 
@@ -577,7 +579,7 @@ To associate a hash with a URL the JSON value is an object:
     - Description
   * - ``url``
     - string (:rfc:`3986`) [``uri-reference``]
-    - An URL.
+    - A URL.
   * - ``hash`` (optional)
     - string
     - A SHA256 hash of the URL content encoded as a hex string.

--- a/source/CIS/cis-1.rst
+++ b/source/CIS/cis-1.rst
@@ -237,6 +237,7 @@ Requirements
 - A transfer of any amount of a token type to a contract address MUST call receive hook function on the receiving smart contract with a :ref:`receive hook parameter<CIS-1-functions-transfer-receive-hook-parameter>`.
 - Let ``operator`` be an operator of the address ``owner``. A transfer of any amount of a token type from an address ``owner`` sent by an address ``operator`` MUST be executed as if the transfer was sent by ``owner``.
 - The contract function MUST reject if a receive hook function called on the contract receiving tokens rejects.
+- The balance of an address not owning any amount of a token type SHOULD be treated as having a balance of zero.
 
 .. warning::
 
@@ -312,6 +313,7 @@ A query-amount pair is serialized as a query (``query``) and then a :ref:`CIS-1-
 Requirements
 ~~~~~~~~~~~~
 
+- The balance of an address not owning any amount of a token type SHOULD be treated as having a balance of zero.
 - The contract function MUST reject if any of the queries fail:
 
   - A query MUST fail if the token ID is unknown with error: :ref:`INVALID_TOKEN_ID<CIS-1-rejection-errors>`.

--- a/source/CIS/cis-1.rst
+++ b/source/CIS/cis-1.rst
@@ -273,6 +273,7 @@ Requirements
 ~~~~~~~~~~~~
 
 - The list of updates MUST be executed in order.
+- The contract function MUST NOT increase or decrease the balance of any address for any token type.
 - The contract function MUST reject if any of the updates fails to be executed.
 
 .. _CIS-1-functions-balanceOf:
@@ -314,6 +315,8 @@ Requirements
 ~~~~~~~~~~~~
 
 - The balance of an address not owning any amount of a token type SHOULD be treated as having a balance of zero.
+- The contract function MUST NOT increase or decrease the balance of any address for any token type.
+- The contract function MUST NOT add or remove any operator for any address.
 - The contract function MUST reject if any of the queries fail:
 
   - A query MUST fail if the token ID is unknown with error: :ref:`INVALID_TOKEN_ID<CIS-1-rejection-errors>`.
@@ -354,6 +357,8 @@ A pair is serialized as a :ref:`CIS-1-TokenID` (``id``) and then a :ref:`CIS-1-M
 Requirements
 ~~~~~~~~~~~~
 
+- The contract function MUST NOT increase or decrease the balance of any address for any token type.
+- The contract function MUST NOT add or remove any operator for any address.
 - The contract function MUST reject if any of the queries fail:
 
   - A query MUST fail if the token ID is unknown with error: :ref:`INVALID_TOKEN_ID<CIS-1-rejection-errors>`.

--- a/source/CIS/cis-1.rst
+++ b/source/CIS/cis-1.rst
@@ -8,9 +8,7 @@ CIS-1: Concordium Token Standard
    * - Created
      - Sep 22, 2021
    * - Final
-     - planned Nov 1, 2021
-   * - Draft version
-     - 3 (Oct 18, 2021)
+     - Nov 1, 2021
 
 Abstract
 ========
@@ -726,7 +724,7 @@ Adding a requirement for owners and operators being authorized to transfer token
 
 Instead, this specification includes a requirement to ensure transfers by operators are executed as if they are sent by the owner, meaning whenever a token owner is authorized, so is an operator of the owner.
 
-Most contracts implementing this specification should probably add some authorization and not have anyone being able to transfer any token, but this is not really relevant for the interface described in this specification.
+Most contracts implementing this specification should probably add some authorization and not have anyone being able to transfer any token, but this is not in the scope of this standard.
 
 No token-level approval/allowance like in ERC20 and ERC721
 ----------------------------------------------------------


### PR DESCRIPTION
## Purpose

Update CIS-1 draft to version 3

## Changes

- Add query for token metadata URL.
- Remove requirement for rejecting non-contract query calls.
- Make query calls, take a contract address for receiving the result of the query.
- Add subsection in Decisions with why there is no explicit authorization.
- Add requirement for accounts without tokens to be treated as balance is 0 for `balanceOf` and `transfer`.
- Add requirement for preserving balances to `updateOperator` and `balanceOf`.
- Add requirement for preserving operators to `balanceOf`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
