### PR TITLE
Introduce CIS-0 Standard Detection

### DIFF
--- a/source/CIS/cis-0.rst
+++ b/source/CIS/cis-0.rst
@@ -58,7 +58,12 @@ A smart contract implementing CIS-0 MUST export the following function: :ref:`CI
 ``supports``
 ^^^^^^^^^^^^
 
-Query supported standards using a list of standard identifers.
+Query supported standards using a list of standard identifers. The response contains a corresponding result for each standard identifier, where the result is either "Standard is not supported", "Standard is supported by this contract" or "Standard is supported by using some contract address".
+
+.. note::
+
+   The result of "Standard is supported by using some contract address" can be used to add support of smart contract standards in another smart contract.
+   This could be to split up logic or to later add support for a new standard.
 
 Parameter
 ~~~~~~~~~
@@ -75,7 +80,7 @@ Response
 The function output is a list of support results, where the order of the support results matches the order of standard identifers in the parameter.
 
 It is serialized as: 2 bytes for the number (little endian) of results (``n``) and then this number of support results (``results``).
-A support result is serialized as either: a byte with value ``0`` for "Standard is not supported", a byte with the value ``1`` for "Standard is support by this contract" or a byte with value ``2`` for "Standard is supported by using another contract address" followed by a single byte encoding the number of contract address then this number of contract addresses (``address``).
+A support result is serialized as either: a byte with value ``0`` for "Standard is not supported", a byte with the value ``1`` for "Standard is support by this contract" or a byte with value ``2`` for "Standard is supported by using another contract address" followed by a single byte encoding the number of contract addresses, then this number of contract addresses (``address``).
 A contract address is serialized as: first 8 bytes for the index (``index``) followed by 8 bytes for the subindex (``subindex``) both little endian::
 
   ContractAddress ::= (index: Byte⁸) (subindex: Byte⁸)

--- a/source/CIS/cis-0.rst
+++ b/source/CIS/cis-0.rst
@@ -1,0 +1,117 @@
+.. _CIS-0:
+
+=========================
+CIS-0: Standard Detection
+=========================
+
+.. list-table::
+   :stub-columns: 1
+
+   * - Created
+     - Jul 14, 2022
+   * - Draft version
+     - 1
+   * - Supported versions
+     - | Smart contract version 1 or newer
+       | (Protocol version 4 or newer)
+   * - Standard identifier
+     - ``CIS-0``
+
+.. warning::
+
+   This standard is still a draft and significant changes might still be made.
+
+Abstract
+========
+
+A standardized interface for how a smart contract publish supported smart contract standards.
+Additionally, this specification includes a list of identifiers for each standard used on the Concordium blockchain.
+
+The interface provides an entrypoint for querying the smart contract, whether it supports a given standard. The smart contract respond with either: not supported, supported or supported by some contract address.
+
+Specification
+=============
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in :rfc:`2119`.
+
+.. _CIS-0-standard-identifer:
+
+Standard identifer
+-------------------
+
+Each standard MUST have a unique identifier.
+An identifier is a variable-length ASCII string up to 100 characters.
+
+The identifier is serialized as: first 1 byte for the length followed this many bytes for the ASCII encoding of the identifier::
+
+  StandardIdentifier ::= (n: Byte) (id: Byteⁿ)
+
+
+The table below contains the current standards and associated standard identifier.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 2 1 1
+
+   * - Standard
+     - Identifier
+     - Encoded
+   * - :ref:`CIS-0`
+     - ``CIS-0``
+     - ``054349532d30``
+   * - :ref:`CIS-1`
+     - ``CIS-1``
+     - ``054349532d31``
+   * - :ref:`CIS-2`
+     - ``CIS-2``
+     - ``054349532d32``
+
+.. note::
+
+   The above table will be expanded with identifers, when new standards are introduced.
+
+Contract functions
+------------------
+
+A smart contract implementing CIS-0 MUST export the following function: :ref:`CIS-0-functions-supports`.
+
+.. _CIS-0-functions-supports:
+
+``supports``
+^^^^^^^^^^^^
+
+Query supported standards using a list of standard identifers.
+
+Parameter
+~~~~~~~~~
+
+The parameter consists of a list of standard identifers.
+
+It is serialized as: 2 bytes for the number (little endian) of standard identifers and then this number of :ref:`CIS-0-standard-identifer` identifers::
+
+  SupportsParameter ::= (n : Byte²) (ids: StandardIdentifierⁿ)
+
+Response
+~~~~~~~~
+
+The function output is a list of support results, where the order of the support results matches the order of standard identifers in the parameter.
+
+It is serialized as: 2 bytes for the number (little endian) of results (``n``) and then this number of support results (``results``).
+A support result is serialized as either: a byte with value ``0`` for "Standard is not supported", a byte with the value ``1`` for "Standard is support by this contract" or a byte with value ``2`` for "Standard is supported by using another contract address" followed by the contract address (``address``).
+A contract address is serialized as: first 8 bytes for the index (``index``) followed by 8 bytes for the subindex (``subindex``) both little endian::
+
+  ContractAddress ::= (index: Byte⁸) (subindex: Byte⁸)
+
+  SupportResult ::= (0 : Byte)                             // Standard is not supported
+                  | (1 : Byte)                             // Standard is supported by this contract
+                  | (2 : Byte) (address: ContractAddress)  // Standard is supported by using another contract address
+
+  SupportsResponse ::= (n : Byte²) (results: SupportResultⁿ)
+
+Requirements
+~~~~~~~~~~~~
+
+- The number of results in the response MUST correspond to the number of the queries in the parameter.
+- The order of results in the response MUST correspond to the order of queries in the parameter.
+- The result for querying the support of ``CIS-0`` for a smart contract implementing this specification MUST NOT be "Standard is not supported".
+

--- a/source/CIS/cis-0.rst
+++ b/source/CIS/cis-0.rst
@@ -46,8 +46,6 @@ The identifier is serialized as: first 1 byte for the length followed this many 
 
   StandardIdentifier ::= (n: Byte) (id: Byteⁿ)
 
-The table below contains the current standards and associated standard identifier.
-
 Contract function
 -----------------
 
@@ -62,7 +60,7 @@ Query supported standards using a list of standard identifers. The response cont
 
 .. note::
 
-   The result of "Standard is supported by using some contract address" can be used to add support of smart contract standards in another smart contract.
+   The result of "Standard is supported by using some contract address" can be used to add support for smart contract standards in another smart contract.
    This could be to split up logic or to later add support for a new standard.
 
 Parameter
@@ -94,7 +92,6 @@ A contract address is serialized as: first 8 bytes for the index (``index``) fol
 Requirements
 ~~~~~~~~~~~~
 
-- The number of results in the response MUST correspond to the number of the queries in the parameter.
-- The order of results in the response MUST correspond to the order of queries in the parameter.
-- The contract function MUST reject if any of the queries fail to produce a result.
+- The sequence of results in the response MUST correspond to the sequence of queries in the parameter.
+- The contract function MAY reject if any of the queries fail to produce a result.
 - The result for querying the support of ``CIS-0`` for a smart contract implementing this specification MUST NOT be "Standard is not supported".

--- a/source/CIS/cis-0.rst
+++ b/source/CIS/cis-0.rst
@@ -24,10 +24,10 @@ CIS-0: Standard Detection
 Abstract
 ========
 
-A standardized interface for how a smart contract publish supported smart contract standards.
+A standardized interface for how a smart contract indicate supported smart contract standards.
 Additionally, this specification includes a list of identifiers for each standard used on the Concordium blockchain.
 
-The interface provides an entrypoint for querying the smart contract, whether it supports a given standard. The smart contract respond with either: not supported, supported or supported by some contract address.
+The interface provides an entrypoint for querying the smart contract about whether it supports a given standard. The smart contract responds with either: not supported, supported or supported by some contract address.
 
 Specification
 =============
@@ -40,38 +40,16 @@ Standard identifer
 -------------------
 
 Each standard MUST have a unique identifier.
-An identifier is a variable-length ASCII string up to 100 characters.
+An identifier is a variable-length ASCII string up to 255 characters.
 
 The identifier is serialized as: first 1 byte for the length followed this many bytes for the ASCII encoding of the identifier::
 
   StandardIdentifier ::= (n: Byte) (id: Byteⁿ)
 
-
 The table below contains the current standards and associated standard identifier.
 
-.. list-table::
-   :header-rows: 1
-   :widths: 2 1 1
-
-   * - Standard
-     - Identifier
-     - Encoded
-   * - :ref:`CIS-0`
-     - ``CIS-0``
-     - ``054349532d30``
-   * - :ref:`CIS-1`
-     - ``CIS-1``
-     - ``054349532d31``
-   * - :ref:`CIS-2`
-     - ``CIS-2``
-     - ``054349532d32``
-
-.. note::
-
-   The above table will be expanded with identifers, when new standards are introduced.
-
-Contract functions
-------------------
+Contract function
+-----------------
 
 A smart contract implementing CIS-0 MUST export the following function: :ref:`CIS-0-functions-supports`.
 
@@ -97,14 +75,14 @@ Response
 The function output is a list of support results, where the order of the support results matches the order of standard identifers in the parameter.
 
 It is serialized as: 2 bytes for the number (little endian) of results (``n``) and then this number of support results (``results``).
-A support result is serialized as either: a byte with value ``0`` for "Standard is not supported", a byte with the value ``1`` for "Standard is support by this contract" or a byte with value ``2`` for "Standard is supported by using another contract address" followed by the contract address (``address``).
+A support result is serialized as either: a byte with value ``0`` for "Standard is not supported", a byte with the value ``1`` for "Standard is support by this contract" or a byte with value ``2`` for "Standard is supported by using another contract address" followed by a single byte encoding the number of contract address then this number of contract addresses (``address``).
 A contract address is serialized as: first 8 bytes for the index (``index``) followed by 8 bytes for the subindex (``subindex``) both little endian::
 
   ContractAddress ::= (index: Byte⁸) (subindex: Byte⁸)
 
   SupportResult ::= (0 : Byte)                             // Standard is not supported
                   | (1 : Byte)                             // Standard is supported by this contract
-                  | (2 : Byte) (address: ContractAddress)  // Standard is supported by using another contract address
+                  | (2 : Byte) (n: Byte) (address: ContractAddressⁿ)  // Standard is supported by using one of these contract addresses.
 
   SupportsResponse ::= (n : Byte²) (results: SupportResultⁿ)
 
@@ -113,5 +91,5 @@ Requirements
 
 - The number of results in the response MUST correspond to the number of the queries in the parameter.
 - The order of results in the response MUST correspond to the order of queries in the parameter.
+- The contract function MUST reject if any of the queries fail to produce a result.
 - The result for querying the support of ``CIS-0`` for a smart contract implementing this specification MUST NOT be "Standard is not supported".
-

--- a/source/CIS/cis-1.rst
+++ b/source/CIS/cis-1.rst
@@ -14,6 +14,8 @@ CIS-1: Concordium Token Standard
    * - Supported versions
      - | Smart contract version 0 or newer
        | (Protocol version 1 or newer)
+   * - Standard identifier
+     - ``CIS-1``
 
 .. warning::
 

--- a/source/CIS/cis-2.rst
+++ b/source/CIS/cis-2.rst
@@ -14,6 +14,10 @@ CIS-2: Concordium Token Standard 2
    * - Supported versions
      - | Smart contract version 1 or newer
        | (Protocol version 4 or newer)
+   * - Standard identifier
+     - ``CIS-2``
+   * - Requires
+     - :ref:`CIS-0<CIS-0>`
    * - Deprecates
      - :ref:`CIS-1<CIS-1>`
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -14,5 +14,6 @@ Concordium Interoperability Specifications
    :maxdepth: 1
    :caption: Standards
 
+   CIS/cis-0
    CIS/cis-1
    CIS/cis-2


### PR DESCRIPTION
## Purpose

Introduce standard for a smart contract to publish the standard they support.
Closes #26.

## Changes

- Add new CIS-0 standard
- Add requirement for implementing CIS-0 in CIS-2.
- Add the corresponding standard identifier in the specification of CIS-1 and CIS-2.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
