### PR TITLE
Mark CIS-0 and CIS-2 as final

### DIFF
--- a/source/CIS/cis-0.rst
+++ b/source/CIS/cis-0.rst
@@ -9,22 +9,18 @@ CIS-0: Standard Detection
 
    * - Created
      - Jul 14, 2022
-   * - Draft version
-     - 1
+   * - Final
+     - Aug 3, 2022
    * - Supported versions
      - | Smart contract version 1 or newer
        | (Protocol version 4 or newer)
    * - Standard identifier
      - ``CIS-0``
 
-.. warning::
-
-   This standard is still a draft and significant changes might still be made.
-
 Abstract
 ========
 
-A standardized interface for how a smart contract indicate supported smart contract standards.
+A standardized interface for how a smart contract indicates supported smart contract standards.
 Additionally, this specification includes a list of identifiers for each standard used on the Concordium blockchain.
 
 The interface provides an entrypoint for querying the smart contract about whether it supports a given standard. The smart contract responds with either: not supported, supported or supported by some contract address.

--- a/source/CIS/cis-2.rst
+++ b/source/CIS/cis-2.rst
@@ -9,8 +9,8 @@ CIS-2: Concordium Token Standard 2
 
    * - Created
      - May 16, 2021
-   * - Draft version
-     - 3
+   * - Final
+     - Aug 3, 2022
    * - Supported versions
      - | Smart contract version 1 or newer
        | (Protocol version 4 or newer)
@@ -20,10 +20,6 @@ CIS-2: Concordium Token Standard 2
      - :ref:`CIS-0<CIS-0>`
    * - Deprecates
      - :ref:`CIS-1<CIS-1>`
-
-.. warning::
-
-   This standard is still a draft and significant changes might still be made.
 
 Abstract
 ========


### PR DESCRIPTION
## Purpose

Mark CIS-0 and CIS-2 as final 

## Changes

- Remove draft warning in CIS0 and CIS2.
- Mark CIS-0 and CIS-2 as final.
